### PR TITLE
Implement services endpoint without ServicesList component

### DIFF
--- a/src/composables/useServices.ts
+++ b/src/composables/useServices.ts
@@ -1,0 +1,43 @@
+import { useQuery } from '@tanstack/vue-query'
+import { watch, type Ref } from 'vue'
+import { storeToRefs } from 'pinia'
+import { getServices } from '@/services/services'
+import { useServicesStore } from '@/stores/services'
+import type { ServiceSimple, ServiceResponse } from '@/types/types'
+
+export function useServices(params?: { skip?: number; limit?: number; search?: string | null }): {
+  services: Ref<ServiceSimple[]>
+  isLoading: Ref<boolean>
+} {
+  const skip = params?.skip ?? 0
+  const limit = params?.limit ?? 100
+  const search = params?.search ?? null
+  const servicesStore = useServicesStore()
+  const { services } = storeToRefs(servicesStore)
+
+  const servicesQuery = useQuery({
+    queryKey: ['services', skip, limit, search],
+    queryFn: (): Promise<ServiceResponse> => getServices(skip, limit, search),
+  })
+
+  watch(
+    servicesQuery.data,
+    (data): void => {
+      if (data) {
+        servicesStore.setServices(data.data)
+      }
+    },
+    { immediate: true },
+  )
+
+  watch(servicesQuery.error, (error): void => {
+    if (error instanceof Error) {
+      console.error('Error fetching services:', error.message)
+    }
+  })
+
+  return {
+    services,
+    isLoading: servicesQuery.isLoading || servicesQuery.isFetching || servicesQuery.isPending,
+  }
+}

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1,0 +1,13 @@
+import { apiService } from '@/api/api'
+import type { ServiceResponse } from '@/types/types'
+
+export const getServices = async (
+  skip: number = 0,
+  limit: number = 100,
+  search: string | null = null,
+): Promise<ServiceResponse> => {
+  const { data } = await apiService.get<ServiceResponse>('/services', {
+    params: { skip, limit, search },
+  })
+  return data
+}

--- a/src/stores/services.ts
+++ b/src/stores/services.ts
@@ -1,0 +1,22 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import type { ServiceSimple } from '@/types/types'
+
+export const useServicesStore = defineStore(
+  'services',
+  (): {
+    services: typeof services
+    setServices: (servicesIn: ServiceSimple[]) => void
+  } => {
+    const services = ref<ServiceSimple[]>([])
+
+    const setServices = (servicesIn: ServiceSimple[]): void => {
+      services.value = servicesIn
+    }
+
+    return {
+      services,
+      setServices,
+    }
+  },
+)

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,35 +1,35 @@
 export interface UserRegister {
-  email: string;
-  full_name: string;
-  password: string;
-  role: string;
-  name: string;
-  phone: string;
-  address: string;
+  email: string
+  full_name: string
+  password: string
+  role: string
+  name: string
+  phone: string
+  address: string
 }
 export interface UserRegisterResponse {
-  email: string;
-  full_name: string;
-  id: number;
-  is_active: boolean;
-  role: string;
-  created_at: string;
+  email: string
+  full_name: string
+  id: number
+  is_active: boolean
+  role: string
+  created_at: string
 }
 
 export interface UserLogin {
-  username: string;
-  password: string;
+  username: string
+  password: string
 }
 
 export interface Token {
-  access_token: string;
-  token_type: string;
+  access_token: string
+  token_type: string
 }
 
 export interface UserLocalStorage {
-  id: number;
-  name: string;
-  email: string;
+  id: number
+  name: string
+  email: string
 }
 
 export enum UserRole {
@@ -39,43 +39,52 @@ export enum UserRole {
 }
 
 export interface ClientSimple {
-  name: string;
-  email: string;
-  phone: string;
-  address: string;
-  id: number;
-  created_at: string;
+  name: string
+  email: string
+  phone: string
+  address: string
+  id: number
+  created_at: string
 }
 
 export interface ServiceSimple {
-  name: string;
-  description: string;
-  price: number;
-  duration: number; // in minutes
-  id: number;
+  name: string
+  description: string
+  price: number
+  duration: number // in minutes
+  id: number
+}
+
+export interface ServiceResponse {
+  info: {
+    page: number
+    per_page: number
+    total: number
+    total_pages: number
+  }
+  data: ServiceSimple[]
 }
 
 export interface Appointment {
-  client_id: number;
-  date: string;
-  notes: string;
-  id: number;
-  client: ClientSimple;
-  services: ServiceSimple[];
-  status: 'pending' | 'confirmed' | 'cancelled';
-  created_at: string;
-  service_ids: number[];
-
+  client_id: number
+  date: string
+  notes: string
+  id: number
+  client: ClientSimple
+  services: ServiceSimple[]
+  status: 'pending' | 'confirmed' | 'cancelled'
+  created_at: string
+  service_ids: number[]
 }
 
 export interface AppointmentResponse {
   info: {
-    page: number;
-    per_page: number;
-    total: number;
-    total_pages: number;
-  },
-  data: Appointment[];
+    page: number
+    per_page: number
+    total: number
+    total_pages: number
+  }
+  data: Appointment[]
 }
 
 export type QalendarEvent = {
@@ -92,6 +101,6 @@ export type QalendarEvent = {
 }
 
 export interface Slot {
-  start: string;
-  end: string;
+  start: string
+  end: string
 }


### PR DESCRIPTION
## Summary
- implement `/services` API calls, composable and store for service data
- remove previously added `ServicesList` component
- revert Home view to previous state

## Testing
- `npx prettier --write src/services/services.ts src/stores/services.ts src/composables/useServices.ts src/views/HomeView.vue src/types/types.ts`
- `npm run lint` *(fails: The 'jiti' library is required for loading TypeScript configuration files)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840151cd50883289b921c4d9bd73d3c