### PR TITLE
Implement appointment modal

### DIFF
--- a/src/components/appointments/CreateAppointmentModal.vue
+++ b/src/components/appointments/CreateAppointmentModal.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+import { Form, Field, ErrorMessage } from 'vee-validate'
+import { appointmentCreateSchema } from '@/types/schemas'
+import { useServices } from '@/composables/useServices'
+import { useAppointments } from '@/composables/useAppointments'
+import { useAuth } from '@/composables/useAuth'
+import type { AppointmentCreate } from '@/types/types'
+
+const props = defineProps<{
+  show: boolean
+  date: string
+}>()
+
+const emit = defineEmits<{ (e: 'close'): void }>()
+
+const { services } = useServices()
+const { createAppointment, isCreating } = useAppointments()
+const { me } = useAuth()
+
+async function onSubmit(values: any): Promise<void> {
+  if (!me.value) return
+  const appointment: AppointmentCreate = {
+    client_id: me.value.client_id,
+    date: props.date,
+    notes: values.notes,
+    service_ids: values.service_ids.map((id: string) => Number(id)),
+  }
+  await createAppointment(appointment)
+  emit('close')
+}
+</script>
+<template>
+  <div v-if="show" class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+    <div class="bg-white rounded-xl shadow-lg p-6 w-full max-w-md">
+      <h3 class="text-lg font-bold mb-4 text-primary-dark">Crear cita</h3>
+      <Form :validation-schema="appointmentCreateSchema" @submit="onSubmit" class="space-y-4">
+        <div>
+          <label class="block text-gray-700 font-mont font-medium">Fecha</label>
+          <input
+            type="text"
+            :value="date"
+            disabled
+            class="w-full rounded border px-3 py-2 mt-1 font-sans text-black bg-gray-100"
+          />
+        </div>
+        <div>
+          <label class="block text-gray-700 font-mont font-medium">Servicios</label>
+          <Field
+            name="service_ids"
+            as="select"
+            multiple
+            class="w-full rounded border px-3 py-2 mt-1 font-sans text-black"
+          >
+            <option v-for="s in services" :key="s.id" :value="s.id">{{ s.name }}</option>
+          </Field>
+          <ErrorMessage name="service_ids" class="text-danger text-xs mt-1" />
+        </div>
+        <div>
+          <label class="block text-gray-700 font-mont font-medium">Notas</label>
+          <Field name="notes" as="textarea" class="w-full rounded border px-3 py-2 mt-1 font-sans text-black" />
+          <ErrorMessage name="notes" class="text-danger text-xs mt-1" />
+        </div>
+        <div class="flex justify-end gap-2">
+          <button type="button" @click="emit('close')" class="btn btn-secondary">Cancelar</button>
+          <button type="submit" class="btn btn-primary" :disabled="isCreating">
+            {{ isCreating ? 'Creando...' : 'Crear' }}
+          </button>
+        </div>
+      </Form>
+    </div>
+  </div>
+</template>

--- a/src/components/dates/Calendar.vue
+++ b/src/components/dates/Calendar.vue
@@ -7,10 +7,14 @@ import type { QalendarEvent } from '@/types/types'
 import { mapAppointmentsToEvents, mapBlockedSlotsToevents } from '@/utils/mappers'
 import { config } from '@/lib/qalendarConfig'
 import { useSlots } from '@/composables/useSlots'
+import { useModal } from '@/composables/useModal'
+import CreateAppointmentModal from '@/components/appointments/CreateAppointmentModal.vue'
 
 const { appointments, isLoading } = useAppointments()
 const { blockedSlots, isLoadingSlots } = useSlots()
 const events = ref<QalendarEvent[]>([])
+const { isOpen, open, close } = useModal()
+const selectedDate = ref('')
 
 watchEffect((): void => {
   const apptEvents = appointments.value ? mapAppointmentsToEvents(appointments.value) : []
@@ -25,11 +29,24 @@ watchEffect((): void => {
   events.value = [...apptEvents, ...filteredBlockedEvents]
   console.log('Events updated:', events.value)
 })
+
+function handleCellClick(event: any): void {
+  if (event && event.time && event.time.start) {
+    selectedDate.value = event.time.start
+    open()
+  }
+}
 </script>
 <template>
   <div class="calendar-container is-light-mode">
-    <Qalendar :events="events" :config="config" :isLoading="isLoading || isLoadingSlots" />
+    <Qalendar
+      :events="events"
+      :config="config"
+      :isLoading="isLoading || isLoadingSlots"
+      @cell-click="handleCellClick"
+    />
   </div>
+  <CreateAppointmentModal :show="isOpen" :date="selectedDate" @close="close" />
 </template>
 <style scoped>
 @import 'qalendar/dist/style.css';

--- a/src/composables/useModal.ts
+++ b/src/composables/useModal.ts
@@ -1,0 +1,15 @@
+import { ref } from 'vue'
+
+export function useModal() {
+  const isOpen = ref(false)
+
+  function open(): void {
+    isOpen.value = true
+  }
+
+  function close(): void {
+    isOpen.value = false
+  }
+
+  return { isOpen, open, close }
+}

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -29,3 +29,8 @@ export const loginSchema = yup.object({
   email: yup.string().email('Formato de email inválido').required('El email es obligatorio'),
   password: yup.string().required('La contraseña es obligatoria'),
 })
+
+export const appointmentCreateSchema = yup.object({
+  service_ids: yup.array().of(yup.number()).min(1, 'Selecciona al menos un servicio'),
+  notes: yup.string().optional(),
+})


### PR DESCRIPTION
## Summary
- use generic useModal composable
- add appointment creation schema
- build CreateAppointmentModal component
- hook modal from Calendar and open on cell click

## Testing
- `npm run lint` *(fails: The 'jiti' library is required)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a5cb6f40832896a9ab22639acfe6