### PR TITLE
Fix service select form

### DIFF
--- a/src/components/appointments/CreateAppointmentModal.vue
+++ b/src/components/appointments/CreateAppointmentModal.vue
@@ -60,7 +60,13 @@ async function onSubmit(values: any): Promise<void> {
           </div>
           <div>
             <label class="block text-gray-700 font-mont font-medium">Servicios</label>
-            <Field name="service_ids" :as="ServiceMultiSelect" :options="services" placeholder="Selecciona servicios" />
+            <Field name="service_ids" v-slot="{ field }">
+              <ServiceMultiSelect
+                v-model="field.value"
+                :options="services"
+                placeholder="Selecciona servicios"
+              />
+            </Field>
             <ErrorMessage name="service_ids" class="text-danger text-xs mt-1" />
           </div>
           <div>


### PR DESCRIPTION
## Summary
- use slot binding for ServiceMultiSelect so vee-validate gets an array

## Testing
- `npm run lint` *(fails: The 'jiti' library is required)*
- `npm run test:unit` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d7608e9c83289b00199aae1636ca