### PR TITLE
Fix service_id map error in appointment creation

### DIFF
--- a/src/components/appointments/CreateAppointmentModal.vue
+++ b/src/components/appointments/CreateAppointmentModal.vue
@@ -33,7 +33,7 @@ async function onSubmit(values: any): Promise<void> {
     client_id: me.value.client_id,
     date: editedDate.value,
     notes: values.notes,
-    service_ids: values.service_ids.map((id: string): number => Number(id)),
+    service_ids: (values.service_ids ?? []).map((id: string): number => Number(id)),
   }
   await createAppointment(appointment)
   emit('close')


### PR DESCRIPTION
## Summary
- handle empty `service_ids` array when creating appointments

## Testing
- `npm run lint` *(fails: The 'jiti' library is required)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840da3c91688328b95d7b741ab2e77c