### PR TITLE
Fix service multi select validation

### DIFF
--- a/src/components/appointments/ServiceMultiSelect.vue
+++ b/src/components/appointments/ServiceMultiSelect.vue
@@ -24,9 +24,13 @@ watch(
   },
 )
 
-watch(localValue, (val): void => {
-  emit('update:modelValue', val)
-})
+watch(
+  localValue,
+  (val): void => {
+    emit('update:modelValue', val)
+  },
+  { deep: true },
+)
 
 const selectedOptions = computed((): ServiceSimple[] =>
   props.options.filter((o): boolean => localValue.value.includes(o.id)),


### PR DESCRIPTION
## Summary
- emit updates from ServiceMultiSelect when the selected array changes deeply

## Testing
- `npm run lint` *(fails: jiti missing)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68414bb2933c832889244168122c6e83