### PR TITLE
Handle unauthorized redirects

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,4 +1,5 @@
 import axios, { type InternalAxiosRequestConfig } from 'axios'
+import router from '@/router'
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
 
@@ -17,3 +18,13 @@ apiService.interceptors.request.use((config): InternalAxiosRequestConfig => {
   }
   return config
 })
+
+apiService.interceptors.response.use(
+  response => response,
+  error => {
+    if (error.response?.status === 401 && !error.config?.url?.includes('/auth/login')) {
+      router.push('/login')
+    }
+    return Promise.reject(error)
+  },
+)

--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -3,6 +3,7 @@ import { ref, watch, type Ref } from 'vue'
 import { useMutation, QueryClient, useQuery } from '@tanstack/vue-query'
 import { useAuthStore } from '@/stores/auth'
 import { storeToRefs } from 'pinia'
+import type { AxiosError } from 'axios'
 import type { UserRegister, UserRegisterResponse, UserLogin, Token, User } from '@/types/types'
 import { useRouter } from 'vue-router'
 
@@ -42,8 +43,12 @@ export const useAuth = (): {
       authStore.setUsername(variables.username)
       router.push('/')
     },
-    onError: (err: Error): void => {
-      error.value = err.message
+    onError: (err: AxiosError | Error): void => {
+      if ((err as AxiosError).isAxiosError && (err as AxiosError).response?.status === 401) {
+        error.value = 'Credenciales incorrectas'
+      } else {
+        error.value = err.message
+      }
     },
   })
 


### PR DESCRIPTION
## Summary
- redirect to login on API 401 responses
- show a credentials error message when login fails

## Testing
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b6f8aa8083288540ec523fcca635